### PR TITLE
Fixes issue #2 and also fixes torchaudio.functional.istsft() Depreciation UserWarning

### DIFF
--- a/dcunet.ipynb
+++ b/dcunet.ipynb
@@ -755,7 +755,8 @@
     "        # u4 - the mask\n",
     "        output = u4 * x\n",
     "        if is_istft:\n",
-    "            output = torchaudio.functional.istft(output, n_fft=self.n_fft, hop_length=self.hop_length, normalized=True)\n",
+    "            output = torch.squeeze(output, 1)\n",
+    "            output = torch.istft(output, n_fft=self.n_fft, hop_length=self.hop_length, normalized=True)\n",
     "        \n",
     "        return output"
    ]
@@ -782,8 +783,10 @@
    "source": [
     "def wsdr_fn(x_, y_pred_, y_true_, eps=1e-8):\n",
     "    # to time-domain waveform\n",
-    "    y_true = torchaudio.functional.istft(y_true_, n_fft=N_FFT, hop_length=HOP_LENGTH, normalized=True)\n",
-    "    x = torchaudio.functional.istft(x_, n_fft=N_FFT, hop_length=HOP_LENGTH, normalized=True)\n",
+    "    y_true_ = torch.squeeze(y_true_, 1)\n",
+    "    x_ = torch.squeeze(x_, 1)\n",
+    "    y_true = torch.istft(y_true_, n_fft=N_FFT, hop_length=HOP_LENGTH, normalized=True)\n",
+    "    x = torch.istft(x_, n_fft=N_FFT, hop_length=HOP_LENGTH, normalized=True)\n",
     "\n",
     "    y_pred = y_pred_.flatten(1)\n",
     "    y_true = y_true.flatten(1)\n",
@@ -983,7 +986,8 @@
     "        noisy_x = noisy_x.to(DEVICE)\n",
     "        with torch.no_grad():\n",
     "            pred_x = net(noisy_x)\n",
-    "        clean_x = torchaudio.functional.istft(clean_x, n_fft=N_FFT, hop_length=HOP_LENGTH, normalized=True)\n",
+    "        clean_x = torch.squeeze(clean_x, 1)\n",
+    "        clean_x = torch.istft(clean_x, n_fft=N_FFT, hop_length=HOP_LENGTH, normalized=True)\n",
     "        \n",
     "        \n",
     "        psq = 0.\n",
@@ -1472,7 +1476,8 @@
     }
    ],
    "source": [
-    "plt.plot(torchaudio.functional.istft(x_c[1], n_fft=N_FFT, hop_length=HOP_LENGTH, normalized=True).view(-1).detach().cpu().numpy())"
+    "x_c[1] = torch.squeeze(x_c[1], 1)\n",
+    "plt.plot(torch.istft(x_c[1], n_fft=N_FFT, hop_length=HOP_LENGTH, normalized=True).view(-1).detach().cpu().numpy())"
    ]
   },
   {
@@ -1525,7 +1530,8 @@
     }
    ],
    "source": [
-    "plt.plot(torchaudio.functional.istft(x_n[1], n_fft=N_FFT, hop_length=HOP_LENGTH, normalized=True).view(-1).detach().cpu().numpy())"
+    "x_n[1] = torch.squeeze(x_n[1], 1)\n",
+    "plt.plot(torch.istft(x_n[1], n_fft=N_FFT, hop_length=HOP_LENGTH, normalized=True).view(-1).detach().cpu().numpy())"
    ]
   },
   {
@@ -1581,9 +1587,9 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python [conda env:dcunet]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-dcunet-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1595,7 +1601,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes pheepa/DCUnet/issues/2

Also Fixes Depreciation Userwarning below
`
torchaudio/torchaudio/functional.py:124: UserWarning: istft has been moved to PyTorch and will be deprecated, please use torch.istft instead.
`
by replacing torchaudio.functional.istft() with torch.istft() instead.